### PR TITLE
Fix nonadjacent qualifiers

### DIFF
--- a/lib/rubocop/cop/alias_method_order_verifier.rb
+++ b/lib/rubocop/cop/alias_method_order_verifier.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require_relative 'qualifier_node_matchers'
+
+module RuboCop
+  module Cop
+    # This verifies a method is defined before its alias
+    class AliasMethodOrderVerifier
+      class << self
+        include IgnoredNode
+        include QualifierNodeMatchers
+
+        ALIAS_BEFORE_METHOD_WARNING_FMT = "Won't reorder " \
+          '%<first_method_name>s and %<second_method_name>s because ' \
+          'alias for %<first_method_name>s would be declared before ' \
+          'its method definition.'
+
+        # rubocop:disable Style/GuardClause
+        def verify!(current_node, previous_node)
+          if moving_after_alias?(current_node, previous_node)
+            ignore_node(current_node)
+            raise_warning!(current_node.method_name, previous_node.method_name)
+          end
+          if moving_after_alias?(previous_node, current_node)
+            ignore_node(previous_node)
+            raise_warning!(previous_node.method_name, current_node.method_name)
+          end
+        end
+        # rubocop:enable Style/GuardClause
+
+        private
+
+        def find_aliases(current_node, siblings)
+          siblings.select do |sibling|
+            (alias?(sibling) || alias_method?(sibling)) ==
+              current_node.method_name
+          end
+        end
+
+        # We don't want a method to be defined after its alias
+        def moving_after_alias?(current_node, previous_node)
+          siblings = current_node.parent.children
+          current_node_aliases = find_aliases(current_node, siblings)
+          filter = current_node_aliases.delete_if do |cna|
+            cna.sibling_index > current_node.sibling_index
+          end
+          return false if filter.empty?
+
+          current_node_aliases.any? do |cna|
+            previous_node.sibling_index > cna.sibling_index
+          end
+        end
+
+        def raise_warning!(first_method_name, second_method_name)
+          raise Warning, format(
+            ALIAS_BEFORE_METHOD_WARNING_FMT,
+            first_method_name: first_method_name,
+            second_method_name: second_method_name
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/qualifier_node_matchers.rb
+++ b/lib/rubocop/cop/qualifier_node_matchers.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    # defines matchers for qualifier nodes
+    module QualifierNodeMatchers
+      extend NodePattern::Macros
+
+      QUALIFIERS = %i[
+        alias_method
+        module_function
+        private_class_method
+        public_class_method
+        private
+        protected
+        public
+      ].freeze
+
+      def_node_matcher :alias?, '(:alias ... (sym $_method_name))'
+      def_node_matcher :alias_method?,
+                       '(send nil? {:alias_method} ... (sym $_method_name))'
+      def_node_matcher :qualifier?, <<-PATTERN
+          (send nil? {#{QUALIFIERS.map(&:inspect).join(' ')}}
+            ... (sym $_method_name))
+      PATTERN
+    end
+  end
+end

--- a/spec/rubocop/cop/layout/ordered_methods_spec.rb
+++ b/spec/rubocop/cop/layout/ordered_methods_spec.rb
@@ -263,4 +263,22 @@ RSpec.describe RuboCop::Cop::Layout::OrderedMethods do
       public :instance_b
     RUBY
   end
+
+  it 'autocorrects when qualifiers are not immediately adjacent' do
+    source = <<-RUBY
+      def method_b; end
+      alias_method :method_from_parent_class_orig, :method_from_parent_class
+      alias_method :method_from_parent_class, :method_b
+
+      def method_a; end
+    RUBY
+
+    expect(autocorrect_source_with_loop(source)).to eq(<<-RUBY)
+      def method_a; end
+
+      def method_b; end
+      alias_method :method_from_parent_class_orig, :method_from_parent_class
+      alias_method :method_from_parent_class, :method_b
+    RUBY
+  end
 end


### PR DESCRIPTION
I had an issue with the auto corrector where it incorrectly put the alias before the method definition. In this instance, it was because there was a qualifier that didn't apply to the node in between the alias_method definition. I think it makes sense to allow that block of code to move together, so I took a stab at fixing it. I've never written a rubocop cop before, so I'd appreciate any feedback.

**Original**
```ruby
class First
  def abc; end
end

class Second < First
  def method_b; end
  alias_method :abc_orig, :abc
  alias_method :abc, :method_b

  def method_a; end
end
```

**Without Fix**
```ruby
class First
  def abc; end
end

class Second < First
  def method_a; end
  alias_method :abc_orig, :abc
  alias_method :abc, :method_b

  def method_b; end
end
```

**With Fix**
```ruby
class First
  def abc; end
end

class Second < First
  def method_a; end

  def method_b; end
  alias_method :abc_orig, :abc
  alias_method :abc, :method_b
end
```