### PR TITLE
Fix NoMethodError and the "[Correctable]" label

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,10 @@ Metrics/BlockLength:
   Exclude:
     - spec/**/*
 
+Metrics/MethodLength:
+  Exclude:
+    - spec/**/*
+
 Naming/FileName:
   Exclude:
     - lib/rubocop-ordered_methods.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- nothing
+### Fixed
+
+- Fix NoMethodError and the "\[Correctable\]" label
 
 ## [0.7] - 2021-01-11
 

--- a/lib/rubocop/cop/layout/ordered_methods.rb
+++ b/lib/rubocop/cop/layout/ordered_methods.rb
@@ -30,6 +30,7 @@ module RuboCop
       #   def c; end
       #   def d; end
       class OrderedMethods < Cop
+        # TODO: Extending Cop is deprecated. Should extend Cop::Base.
         include IgnoredMethods
         include RangeHelp
 
@@ -72,12 +73,13 @@ module RuboCop
           @cache ||= begin
             @siblings = node.children
 
-            # Init the corrector with the cache to avoid traversing
-            # the AST in the corrector
-            if @options[:auto_correct]
-              comments = processed_source.ast_with_comments
-              @corrector = OrderedMethodsCorrector.new(comments, @siblings)
-            end
+            # Init the corrector with the cache to avoid traversing the AST in
+            # the corrector. We always init the @corrector, even if
+            # @options[:auto_correct] is nil, because `add_offense` always
+            # attempts correction. This correction attempt is how RuboCop knows
+            # if the offense can be labeled "[Correctable]".
+            comments = processed_source.ast_with_comments
+            @corrector = OrderedMethodsCorrector.new(comments, @siblings)
           end
         end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,10 @@ require 'rubocop'
 require 'rubocop/rspec/support'
 require 'rubocop-ordered_methods'
 
+# Require supporting files (custom matchers and macros, etc)
+# in ./support and its subdirectories.
+Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].sort.each { |f| require f }
+
 RSpec.configure do |config|
   config.define_derived_metadata(file_path: %r{/spec/rubocop/cop/}) do |meta|
     meta[:type] = :cop_spec

--- a/spec/support/file_helper.rb
+++ b/spec/support/file_helper.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+
+# Copied from `rubocop/spec/support/file_helper.rb`
+module FileHelper
+  def create_file(file_path, content)
+    file_path = File.expand_path(file_path)
+
+    dir_path = File.dirname(file_path)
+    FileUtils.makedirs dir_path unless File.exist?(dir_path)
+
+    File.open(file_path, 'w') do |file|
+      case content
+      when String
+        file.puts content
+      when Array
+        file.puts content.join("\n")
+      end
+    end
+
+    file_path
+  end
+
+  def create_empty_file(file_path)
+    create_file(file_path, '')
+  end
+end


### PR DESCRIPTION
Because we weren't always initializing our `@corrector`, a NoMethodError
was occurring in `#autocorrect`. Example output from `rubocop --debug`:

```
Scanning redacted.rb
An error occurred while Layout/OrderedMethods cop was inspecting redacted.rb:24:2.
undefined method `correct' for nil:NilClass
/Users/jared/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rubocop-ordered_methods-0.7/lib/rubocop/cop/layout/ordered_methods.rb:45:in `autocorrect'
/Users/jared/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rubocop-1.9.1/lib/rubocop/cop/cop.rb:142:in `block in correction_lambda'
/Users/jared/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rubocop-1.9.1/lib/rubocop/cop/cop.rb:148:in `dedup_on_node'
/Users/jared/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rubocop-1.9.1/lib/rubocop/cop/cop.rb:141:in `correction_lambda'
/Users/jared/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rubocop-1.9.1/lib/rubocop/cop/cop.rb:125:in `emulate_v0_callsequence'
/Users/jared/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rubocop-1.9.1/lib/rubocop/cop/cop.rb:34:in `block in add_offense'
/Users/jared/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rubocop-1.9.1/lib/rubocop/cop/base.rb:340:in `correct'
/Users/jared/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rubocop-1.9.1/lib/rubocop/cop/base.rb:127:in `add_offense'
/Users/jared/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rubocop-1.9.1/lib/rubocop/cop/cop.rb:33:in `add_offense'
/Users/jared/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rubocop-ordered_methods-0.7/lib/rubocop/cop/layout/ordered_methods.rb:53:in `block in on_begin'
/Users/jared/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rubocop-ordered_methods-0.7/lib/rubocop/cop/layout/ordered_methods.rb:92:in `block (2 levels) in consecutive_methods'
/Users/jared/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rubocop-ordered_methods-0.7/lib/rubocop/cop/layout/ordered_methods.rb:91:in `each'
/Users/jared/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rubocop-ordered_methods-0.7/lib/rubocop/cop/layout/ordered_methods.rb:91:in `each_cons'
/Users/jared/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rubocop-ordered_methods-0.7/lib/rubocop/cop/layout/ordered_methods.rb:91:in `block in consecutive_methods'
/Users/jared/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rubocop-ordered_methods-0.7/lib/rubocop/cop/layout/ordered_methods.rb:90:in `each'
/Users/jared/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rubocop-ordered_methods-0.7/lib/rubocop/cop/layout/ordered_methods.rb:90:in `consecutive_methods'
/Users/jared/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rubocop-ordered_methods-0.7/lib/rubocop/cop/layout/ordered_methods.rb:50:in `on_begin'
...
```