### PR TITLE
Autocorrection support for Sorbet signatures

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,3 +24,9 @@ Metrics/MethodLength:
 Naming/FileName:
   Exclude:
     - lib/rubocop-ordered_methods.rb
+
+# Use the semantic style. If a block has side effects use `do`, and if it is
+# pure use `{}`. This style is too nuanced for a linter, so the cop is
+# disabled.
+Style/BlockDelimiters:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,12 @@ AllCops:
   SuggestExtensions: false
   TargetRubyVersion: 2.4
 
+# Subtle, left to author's discretion. In a long method with many guard clauses,
+# a blank line may help. But, in a short method, especially with only a single
+# guard clause, a blank line can be disruptive.
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
+
 Metrics/BlockLength:
   Exclude:
     - spec/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Autocorrection support for Sorbet signatures
+
 ## [0.8] - 2021-02-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -74,8 +74,19 @@ rubocop --require rubocop-ordered_methods
 
 Name | Default value | Configurable values
 --- | --- | ---
-EnforcedStyle | `alphabetical` | `alphabetical`
-IgnoredMethods | `initialize` | Array
+EnforcedStyle | `'alphabetical'` | `'alphabetical'`
+IgnoredMethods | `['initialize']` | Array
+Signature | `nil` | `'sorbet'`, `nil`
+
+#### Example
+
+```
+# .rubocop.yml
+Layout/OrderedMethods:
+  EnforcedStyle: alphabetical
+  IgnoredMethods: initialize
+  Signature: sorbet
+```
 
 ### Corrector
 
@@ -124,6 +135,13 @@ private :instance_a
 protected :instance_a
 public :instance_a
 ```
+
+#### Method signatures
+
+Support for (Sorbet) method signatures was added to the corrector by
+[#7](https://github.com/shanecav84/rubocop-ordered_methods/pull/7).
+It is off by default due to performance concerns (not yet benchmarked). Enable
+with `Signature: sorbet`.
 
 #### Caveats
 

--- a/lib/rubocop/cop/correctors/ordered_methods_corrector.rb
+++ b/lib/rubocop/cop/correctors/ordered_methods_corrector.rb
@@ -45,6 +45,9 @@ module RuboCop
         (qualifier?(next_sibling) || alias?(next_sibling)) == node.method_name
       end
 
+      # @param node RuboCop::AST::DefNode
+      # @param source_range Parser::Source::Range
+      # @return Parser::Source::Range
       def join_comments(node, source_range)
         @comments[node].each do |comment|
           source_range = source_range.join(comment.loc.expression)
@@ -52,6 +55,9 @@ module RuboCop
         source_range
       end
 
+      # @param node RuboCop::AST::DefNode
+      # @param source_range Parser::Source::Range
+      # @return Parser::Source::Range
       def join_modifiers_and_aliases(node, source_range)
         preceding_qualifier_index = node.sibling_index
         last_qualifier_index = find_last_qualifier_index(node)
@@ -64,12 +70,38 @@ module RuboCop
         source_range
       end
 
+      # @param node RuboCop::AST::DefNode
+      # @param source_range Parser::Source::Range
+      # @return Parser::Source::Range
+      def join_signature(node, source_range)
+        sib = node.left_sibling
+        if signature?(sib)
+          # If there is a comment directly above the sig, first calculate the
+          # range that covers both.
+          with_comment = join_comments(sib, sib.source_range)
+          source_range.join(with_comment)
+        else
+          source_range
+        end
+      end
+
+      # @param node RuboCop::AST::DefNode
+      # @return Parser::Source::Range
       def join_surroundings(node)
         with_modifiers_and_aliases = join_modifiers_and_aliases(
           node,
           node.source_range
         )
-        join_comments(node, with_modifiers_and_aliases)
+        with_comments = join_comments(node, with_modifiers_and_aliases)
+        join_signature(node, with_comments)
+      end
+
+      # https://sorbet.org/docs/sigs
+      # @param node RuboCop::AST::Node
+      def signature?(node)
+        return false unless node&.type == :block
+        child = node.children.first
+        child&.type == :send && child.method_name == :sig
       end
     end
   end

--- a/lib/rubocop/cop/correctors/ordered_methods_corrector.rb
+++ b/lib/rubocop/cop/correctors/ordered_methods_corrector.rb
@@ -10,9 +10,11 @@ module RuboCop
     class OrderedMethodsCorrector
       include QualifierNodeMatchers
 
-      def initialize(comments, siblings)
+      # @param cop_config ::RuboCop::Config
+      def initialize(comments, siblings, cop_config)
         @comments = comments
         @siblings = siblings
+        @cop_config = cop_config
       end
 
       def correct(node, previous_node)
@@ -85,6 +87,10 @@ module RuboCop
         end
       end
 
+      def join_signature?
+        @cop_config['Signature'] == 'sorbet'
+      end
+
       # @param node RuboCop::AST::DefNode
       # @return Parser::Source::Range
       def join_surroundings(node)
@@ -93,7 +99,11 @@ module RuboCop
           node.source_range
         )
         with_comments = join_comments(node, with_modifiers_and_aliases)
-        join_signature(node, with_comments)
+        if join_signature?
+          join_signature(node, with_comments)
+        else
+          with_comments
+        end
       end
 
       # https://sorbet.org/docs/sigs

--- a/lib/rubocop/cop/layout/ordered_methods.rb
+++ b/lib/rubocop/cop/layout/ordered_methods.rb
@@ -74,12 +74,14 @@ module RuboCop
             @siblings = node.children
 
             # Init the corrector with the cache to avoid traversing the AST in
-            # the corrector. We always init the @corrector, even if
-            # @options[:auto_correct] is nil, because `add_offense` always
-            # attempts correction. This correction attempt is how RuboCop knows
-            # if the offense can be labeled "[Correctable]".
+            # the corrector.
+            #
+            # We always init the @corrector, even if @options[:auto_correct] is
+            # nil, because `add_offense` always attempts correction. This
+            # correction attempt is how RuboCop knows if the offense can be
+            # labeled "[Correctable]".
             comments = processed_source.ast_with_comments
-            @corrector = OrderedMethodsCorrector.new(comments, @siblings)
+            @corrector = OrderedMethodsCorrector.new(comments, @siblings, cop_config)
           end
         end
 

--- a/rubocop-ordered_methods.gemspec
+++ b/rubocop-ordered_methods.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rubocop', '>= 1.0'
 
   spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'rake', '~> 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
 end

--- a/spec/rubocop/cop/layout/ordered_methods_spec.rb
+++ b/spec/rubocop/cop/layout/ordered_methods_spec.rb
@@ -282,6 +282,34 @@ RSpec.describe RuboCop::Cop::Layout::OrderedMethods do
     RUBY
   end
 
+  it 'autocorrects methods with Sorbet signatures' do
+    new_source = autocorrect_source_file(<<~RUBY)
+      class Foo
+        # Comment b
+        def b; end
+        # Comment a
+        sig { params(x: Integer).returns(String) }
+        def a(x)
+          x.to_s
+        end
+        alias_method :a2, :a
+      end
+    RUBY
+
+    expect(new_source).to eq(<<~RUBY)
+      class Foo
+        # Comment a
+        sig { params(x: Integer).returns(String) }
+        def a(x)
+          x.to_s
+        end
+        alias_method :a2, :a
+        # Comment b
+        def b; end
+      end
+    RUBY
+  end
+
   # We integration-test our cop via `::RuboCop::CLI`. This is quite close to an
   # end-to-end test, with the normal pros and cons that entails. We exercise
   # more of our code, but our assertions are more fragile, for example asserting

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'byebug'
 require 'rubocop'
 require 'rubocop/rspec/support'
 require 'rubocop-ordered_methods'


### PR DESCRIPTION
https://sorbet.org/docs/sigs

## Input

```ruby
class Foo
  # Comment b
  def b; end
  # Comment a
  sig { params(x: Integer).returns(String) }
  def a(x)
    x.to_s
  end
  alias_method :a2, :a
end
```

## Output

```ruby
class Foo
  # Comment a
  sig { params(x: Integer).returns(String) }
  def a(x)
    x.to_s
  end
  alias_method :a2, :a
  # Comment b
  def b; end
end
```

Fixes https://github.com/shanecav84/rubocop-ordered_methods/issues/3