### PR TITLE
Setup CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby:
+          - "2.7"
+          - "3.0"
+          - "3.1"
+          - "3.2"
+
+    name: "Ruby ${{ matrix.ruby }}: run tests"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "${{ matrix.ruby }}"
+          bundler-cache: true
+      - run:  bundle exec rspec


### PR DESCRIPTION
Setups GitHub action to run the specs on an open PR.

I've used 2.4 as the ruby version, as that's what specified as a minimum required version in the gem spec.
Let me know if you want me to add a matrix for testing on ruby versions 2.4 ... 3.2
Also, perhaps it's time to drop support for EOL ruby versions anyway