### PR TITLE
Add MethodQualifiers to the default config

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -4,4 +4,5 @@ Layout/OrderedMethods:
   EnforcedStyle: 'alphabetical'
   IgnoredMethods:
     - initialize
+  MethodQualifiers: []
   Signature: ~


### PR DESCRIPTION
This fixes the warning:
```
Warning: Layout/OrderedMethods does not support MethodQualifiers parameter.

Supported parameters are:

  - Enabled
  - EnforcedStyle
  - IgnoredMethods
  - Signature
```

The configuration itself work, but the warning is annoying. I've missed that in #11 :/