### PR TITLE
Fix handling require at the top of the file, nil nodes, and nodes that aren't of type AST::node

### DIFF
--- a/lib/rubocop/cop/layout/ordered_methods.rb
+++ b/lib/rubocop/cop/layout/ordered_methods.rb
@@ -54,7 +54,9 @@ module RuboCop
         end
 
         def on_begin(node)
-          siblings, _corrector = cache(node)
+          start_node = node.children.find { |child| child.class_type? }&.children&.last || node
+          siblings, _corrector = cache(start_node)
+
           consecutive_methods(siblings) do |previous, current|
             unless ordered?(previous, current)
               @previous_node = previous

--- a/lib/rubocop/cop/layout/ordered_methods.rb
+++ b/lib/rubocop/cop/layout/ordered_methods.rb
@@ -120,7 +120,8 @@ module RuboCop
         # rubocop:enable Style/ExplicitBlockArgument
 
         def filter_relevant_nodes(nodes)
-          nodes.select do |node|
+          nodes.compact.select do |node|
+            next unless node.is_a?(Parser::AST::Node)
             relevant_node?(node) || (node.send_type? && qualifier_macro?(node))
           end
         end

--- a/spec/rubocop/cop/layout/ordered_methods_spec.rb
+++ b/spec/rubocop/cop/layout/ordered_methods_spec.rb
@@ -87,6 +87,16 @@ RSpec.describe RuboCop::Cop::Layout::OrderedMethods do
     RUBY
   end
 
+  it 'does not register an offense when there are nodes in the class but no methods' do
+    expect_no_offenses(<<-RUBY.gsub(/^\s+\|/, ''))
+      require "../app/lib/bar"
+
+      class Foo
+        include Bar
+      end
+    RUBY
+  end
+
   it 'autocorrects methods that are not in alphabetical order' do
     new_source = autocorrect_source_file(<<-RUBY.gsub(/^\s+\|/, ''))
       class Foo

--- a/spec/rubocop/cop/layout/ordered_methods_spec.rb
+++ b/spec/rubocop/cop/layout/ordered_methods_spec.rb
@@ -68,6 +68,18 @@ RSpec.describe RuboCop::Cop::Layout::OrderedMethods do
     RUBY
   end
 
+  it 'registers an offense when require is present at the top of the file (regression)' do
+    expect_offense(<<-RUBY.gsub(/^\s+\|/, ''))
+      require "date"
+
+      class Foo
+        def self.class_b; end
+        def self.class_a; end
+        ^^^^^^^^^^^^^^^^^^^^^ Methods should be sorted in alphabetical order.
+      end
+    RUBY
+  end
+
   it 'does not register an offense when methods are in alphabetical order' do
     expect_no_offenses(<<-RUBY.gsub(/^\s+\|/, ''))
       def a; end


### PR DESCRIPTION
Hello! This fixes three things we had an issue with:
- Having 'require' at the top of the file
- Having a nil node in the siblings array
- Having a node that isn't of type Parser::AST::node

Let me know if you need me to do anything else!