### PR TITLE
Fix rubocop 1.65 compatability

### DIFF
--- a/lib/rubocop/cop/correctors/ordered_methods_corrector.rb
+++ b/lib/rubocop/cop/correctors/ordered_methods_corrector.rb
@@ -17,14 +17,11 @@ module RuboCop
         @cop_config = cop_config
       end
 
-      def correct(node, previous_node)
+      def correct(node, previous_node, corrector)
         AliasMethodOrderVerifier.verify!(node, previous_node)
         current_range = join_surroundings(node)
         previous_range = join_surroundings(previous_node)
-        lambda do |corrector|
-          corrector.replace(current_range, previous_range.source)
-          corrector.replace(previous_range, current_range.source)
-        end
+        corrector.swap(current_range, previous_range)
       end
 
       private
@@ -51,7 +48,7 @@ module RuboCop
       # @param source_range Parser::Source::Range
       # @return Parser::Source::Range
       def join_comments(node, source_range)
-        @comment_locations[node.loc].each do |comment|
+        @comment_locations[node].each do |comment|
           source_range = source_range.join(comment.loc.expression)
         end
         source_range

--- a/rubocop-ordered_methods.gemspec
+++ b/rubocop-ordered_methods.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'rubocop', '>= 1.0'
+  spec.add_dependency 'rubocop', '>= 1.0'
 
   spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/spec/support/file_helper.rb
+++ b/spec/support/file_helper.rb
@@ -4,6 +4,10 @@ require 'fileutils'
 
 # Copied from `rubocop/spec/support/file_helper.rb`
 module FileHelper
+  def create_empty_file(file_path)
+    create_file(file_path, '')
+  end
+
   def create_file(file_path, content)
     file_path = File.expand_path(file_path)
 
@@ -20,9 +24,5 @@ module FileHelper
     end
 
     file_path
-  end
-
-  def create_empty_file(file_path)
-    create_file(file_path, '')
   end
 end


### PR DESCRIPTION
`ignored_method?` was an alias for alias for `allowed_method?` for ages. Rubocop 1.65 [broke than [method](https://github.com/rubocop/rubocop/pull/13032/files#diff-0a7e1a4295ae0c7bb4b3a11e123e112717633dea6385d36ab7d75c8c39630be4R18)(by essentially making the signature incompatible).
~This just allows running the cop with no errors. It still produces deprecation warnings around the auto-correct deprecation~
Also updated the auto-corrector to use the new API.
Note: I don't see any reason for the caching of the corrector, as nodes are simply passed to the constructor, but traversed during the actual correction. Since RuboCop executed the check again after each correction though (which changed the AST), we should not use a cached version of the siblings.
