### PR TITLE
rubocop-ordered_methods ignores outer classes when inspecting files

### DIFF
--- a/lib/rubocop/cop/layout/ordered_methods.rb
+++ b/lib/rubocop/cop/layout/ordered_methods.rb
@@ -49,8 +49,9 @@ module RuboCop
         end
 
         def on_begin(node)
-          start_node = node.children.find(&:class_type?)&.children&.last || node
-          check(start_node)
+          check(node)
+
+          node.each_descendant(:class, :module) { |descendant| check(descendant) }
         end
 
         private

--- a/spec/rubocop/cop/layout/ordered_methods_spec.rb
+++ b/spec/rubocop/cop/layout/ordered_methods_spec.rb
@@ -334,6 +334,79 @@ RSpec.describe RuboCop::Cop::Layout::OrderedMethods do
     RUBY
   end
 
+  context 'when a class has inner classes/modules' do
+    let(:expected_offense) do
+      <<~RUBY
+        class Parent
+          def self.parent_b; end
+          def self.parent_a; end
+          ^^^^^^^^^^^^^^^^^^^^^^ Methods should be sorted in alphabetical order.
+
+          def parent_instance_b; end
+          def parent_instance_a; end
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^ Methods should be sorted in alphabetical order.
+
+          class Child
+            def self.child_b; end
+            def self.child_a; end
+            ^^^^^^^^^^^^^^^^^^^^^ Methods should be sorted in alphabetical order.
+
+            def child_instance_b; end
+            def child_instance_a; end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^ Methods should be sorted in alphabetical order.
+          end
+
+          module InnerModule
+            def self.inner_module_b; end
+            def self.inner_module_a; end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Methods should be sorted in alphabetical order.
+
+            def inner_instance_b; end
+            def inner_instance_a; end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^ Methods should be sorted in alphabetical order.
+          end
+        end
+      RUBY
+    end
+
+    let(:expected_correction) do
+      <<~RUBY
+        class Parent
+          def self.parent_a; end
+          def self.parent_b; end
+
+          def parent_instance_a; end
+          def parent_instance_b; end
+
+          class Child
+            def self.child_a; end
+            def self.child_b; end
+
+            def child_instance_a; end
+            def child_instance_b; end
+          end
+
+          module InnerModule
+            def self.inner_module_a; end
+            def self.inner_module_b; end
+
+            def inner_instance_a; end
+            def inner_instance_b; end
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense for methods not in alphabetical order in inner classes and modules' do
+      expect_offense(expected_offense)
+      expect_correction(expected_correction)
+    end
+
+    it 'does not register an offense for methods in alphabetical order in inner classes and modules' do
+      expect_no_offenses(expected_correction)
+    end
+  end
+
   context 'with config `Signature: sorbet`' do
     let(:cop_config) { { 'Signature' => 'sorbet' } }
 


### PR DESCRIPTION
# Issue
When a class has subclasses, the cop ignores the outer class and inspects only the subclass.

# Fix
Inspect the outer class and each descendant of the outer class.

# Expectations
Given the class `parent.rb`
```
class Parent
  def self.parent_b; end
  def self.parent_a; end

  def parent_instance_b; end
  def parent_instance_a; end

  class Child
    def self.child_b; end
    def self.child_a; end

    def child_instance_b; end
    def child_instance_a; end
  end

  module InnerModule
    def self.inner_module_b; end
    def self.inner_module_a; end

    def inner_instance_b; end
    def inner_instance_a; end
  end
end


```
Expected output when we run `rubocop parent.rb --only Layout/OrderedMethods` 

```
Inspecting 1 file
C

Offenses:

parent.rb:3:3: C: [Correctable] Layout/OrderedMethods: Methods should be sorted in alphabetical order.
  def self.parent_a; end
  ^^^^^^^^^^^^^^^^^^^^^^
parent.rb:6:3: C: [Correctable] Layout/OrderedMethods: Methods should be sorted in alphabetical order.
  def parent_instance_a; end
  ^^^^^^^^^^^^^^^^^^^^^^^^^^
parent.rb:10:5: C: [Correctable] Layout/OrderedMethods: Methods should be sorted in alphabetical order.
    def self.child_a; end
    ^^^^^^^^^^^^^^^^^^^^^
parent.rb:13:5: C: [Correctable] Layout/OrderedMethods: Methods should be sorted in alphabetical order.
    def child_instance_a; end
    ^^^^^^^^^^^^^^^^^^^^^^^^^
parent.rb:18:5: C: [Correctable] Layout/OrderedMethods: Methods should be sorted in alphabetical order.
    def self.inner_module_a; end
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
parent.rb:21:5: C: [Correctable] Layout/OrderedMethods: Methods should be sorted in alphabetical order.
    def inner_instance_a; end
    ^^^^^^^^^^^^^^^^^^^^^^^^^
```

Actual output  when we run `rubocop parent.rb --only Layout/OrderedMethods`
```
Inspecting 1 file
C

Offenses:

parent.rb:10:5: C: [Correctable] Layout/OrderedMethods: Methods should be sorted in alphabetical order.
    def self.child_a; end
    ^^^^^^^^^^^^^^^^^^^^^
parent.rb:13:5: C: [Correctable] Layout/OrderedMethods: Methods should be sorted in alphabetical order.
    def child_instance_a; end
    ^^^^^^^^^^^^^^^^^^^^^^^^^
parent.rb:18:5: C: [Correctable] Layout/OrderedMethods: Methods should be sorted in alphabetical order.
    def self.inner_module_a; end
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
parent.rb:21:5: C: [Correctable] Layout/OrderedMethods: Methods should be sorted in alphabetical order.
    def inner_instance_a; end
    ^^^^^^^^^^^^^^^^^^^^^^^^^
```

**Notice we're missing inspections for: `Parent.parent_a`, `Parent#parent_instance_a`**

RE: [OrderedMethods fails to scan classes that have siblings #8
](https://github.com/shanecav84/rubocop-ordered_methods/issues/8)